### PR TITLE
fix(ci): do not send notification for failed pr build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js: 10
 
 after_failure:
   - chmod +x ./travis/webhook.sh
-  - ./travis/webhook.sh
+  - 'if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ]; then ./travis/webhook.sh; fi'
 
 jobs:
     include:


### PR DESCRIPTION
This PR will avoid sending a webhook notification for failed PR builds. (Overlooked in #25)