### PR TITLE
refactor(reload): allow multiple commands, more packed output

### DIFF
--- a/src/commands/unique/reload.ts
+++ b/src/commands/unique/reload.ts
@@ -59,7 +59,7 @@ class ReloadCommand extends Command {
 			try {
 				await client.commandHandler.reloadCommand(command);
 			} catch (e) {
-				failures.push([command, require('discord.js').Util.makePlainError(e) as IPlainError])
+				failures.push([command, require('discord.js').Util.makePlainError(e) as IPlainError]);
 			}
 		}
 

--- a/src/extensions/ShardClientUtil.ts
+++ b/src/extensions/ShardClientUtil.ts
@@ -40,7 +40,9 @@ class ShardClientUtilExtension {
 		if (typeof fn !== 'string') {
 			stringified = String(fn);
 
-			if (!/(^function|^\(.*\) =>)/.test(stringified)) {
+			if (/^async .* \{/.test(stringified)) {
+				stringified = `async function ${stringified.slice(5)}`;
+			} else if (!/(^function|^\(.*\) =>)/.test(stringified)) {
 				stringified = `function ${stringified}`;
 			}
 


### PR DESCRIPTION
This PR allows the reload command to reload multiple commands at once.
Additionally it reduced the output produced by only reporting single errors if they happen and a general "all good" if not.