### PR TITLE
fix: actually post to bot lists

### DIFF
--- a/src/extensions/ShardClientUtil.ts
+++ b/src/extensions/ShardClientUtil.ts
@@ -16,8 +16,16 @@ class ShardClientUtilExtension {
 		if (message._fetchProp) {
 			const props: string[] = message._fetchProp.split('.');
 			let value: any = this.client;
-			for (const prop of props) value = value[prop];
-			this._respond('fetchProp', { _fetchProp: message._fetchProp, _result: value });
+			try {
+				for (const prop of props) value = value[prop];
+
+				// Checking for circulars; Not reassigning is intended.
+				JSON.stringify(value);
+
+				this._respond('fetchProp', { _fetchProp: message._fetchProp, _result: value });
+			} catch (err) {
+				this._respond('fetchProp', { _fetchProp: message._fetchProp, _error: Util.makePlainError(err) });
+			}
 		} else if (message._eval) {
 			try {
 				const _result: any = await this.client._eval(message._eval);

--- a/src/util/botlists.ts
+++ b/src/util/botlists.ts
@@ -17,7 +17,7 @@ const DBotsOrg: () => APIRouter = buildRouter({
 });
 
 export async function updateBotLists(this: Client): Promise<void> {
-	const count: number = await this.shard.fetchClientValues('guild.size')
+	const count: number = await this.shard.fetchClientValues('guilds.size')
 		.then((res: number[]) => res.reduce((p: number, c: number) => p + c));
 
 	// No webhook, that would just spam


### PR DESCRIPTION
This PR fixes a typo which causes the botlists update function to throw in an error when fetching the guild count from all shards.