### PR TITLE
Add the ability for users to hide their relationship status

### DIFF
--- a/src/commands/user/hidepartner.ts
+++ b/src/commands/user/hidepartner.ts
@@ -1,0 +1,31 @@
+import { Message } from 'discord.js';
+
+import { Command } from '../../structures/Command';
+import { CommandHandler } from '../../structures/CommandHandler';
+import { ICommandRunInfo } from '../../types/ICommandRunInfo';
+
+class HidePartnerCommand extends Command {
+	public constructor(handler: CommandHandler) {
+		super(handler, {
+			description: 'Hides or unhides your partner in your profile.',
+			examples: ['hidepartner'],
+			exp: 0,
+			usage: 'hidepartner',
+		});
+	}
+
+	public async run(message: Message, _: string[], { authorModel }: ICommandRunInfo)
+		: Promise<any> {
+		const response: string = authorModel.partnerHidden
+			? 'your partner is no longer hidden.'
+			: 'your partner is now hidden.';
+
+		authorModel.partnerHidden = !authorModel.partnerHidden;
+		await authorModel.save();
+
+		return message.reply(response);
+	}
+
+}
+
+export { HidePartnerCommand as Command };

--- a/src/commands/user/profile.ts
+++ b/src/commands/user/profile.ts
@@ -64,14 +64,18 @@ class ProfileCommand extends Command {
 			},
 		);
 
-		const partner: User | undefined = userModel.partnerId
-			? this.client.users.get(userModel.partnerId)
-			|| await this.client.users.fetch(userModel.partnerId).catch(() => undefined)
-			: undefined;
+		let partnerString: string = 'Hidden';
 
-		const partnerString: string = partner
-			? `${userModel.partnerMarried ? 'Married' : 'Together'} with **${partner.tag}**`
-			: 'Single';
+		if (!userModel.partnerHidden) {
+			const partner: User | undefined = userModel.partnerId
+				? this.client.users.get(userModel.partnerId)
+				|| await this.client.users.fetch(userModel.partnerId).catch(() => undefined)
+				: undefined;
+
+			partnerString = partner
+				? `${userModel.partnerMarried ? 'Married' : 'Together'} with **${partner.tag}**`
+				: 'Single';
+		}
 
 		return MessageEmbed.common({ author }, userModel)
 			.setThumbnail(guild.iconURL())

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -55,9 +55,10 @@ export class User extends Model<User> {
 	/**
 	 * Build a User model from redis data.
 	 */
-	public static fromRedis(data: { [key: string]: string | number | Date }): User {
+	public static fromRedis(data: { [key: string]: string | number | Date | boolean }): User {
 		if (data.partnerSince) data.partnerSince = new Date(Number(data.partnerSince));
 
+		data.partnerHidden = data.partnerHidden === 'true';
 		data.exp = Number(data.exp) || 0;
 		data.tier = Number(data.tier) || 0;
 
@@ -240,6 +241,13 @@ export class User extends Model<User> {
 		type: DataType.BOOLEAN,
 	})
 	public partnerMarried!: boolean | null;
+
+	@Column({
+		defaultValue: false,
+		field: 'partner_hidden',
+		type: DataType.BOOLEAN,
+	})
+	public partnerHidden!: boolean;
 
 	@BelongsToMany(() => Badge, {
 		as: 'badges',


### PR DESCRIPTION
This PR adds the functionality for users to hide their relationship status (if they are in one, and with who).

Edits the `users` table by adding a column, will require database migration before deploying.