### PR TITLE
fix(SetGameCommand): do not send url if not streaming

### DIFF
--- a/src/commands/unique/setgame.ts
+++ b/src/commands/unique/setgame.ts
@@ -28,7 +28,7 @@ class SetGameCommand extends Command {
 			let stream: string = '';
 			if (args[0].toLowerCase() === 'stream') {
 				args = args.slice(1);
-				stream = ', \'https://twitch.tv/wizardlink\'';
+				stream = 'https://twitch.tv/wizardlink';
 			}
 
 			await this.client.shard.broadcastEval(this.setActivity, [args.join(' '), stream]);
@@ -44,7 +44,7 @@ class SetGameCommand extends Command {
 					name: `${game} [${shardId}]`,
 					shardID: shardId,
 					type: stream ? 'STREAMING' : 'PLAYING',
-					url: stream,
+					url: stream || undefined,
 				}),
 			),
 		);


### PR DESCRIPTION
This PR fixes two bugs in the `SetGameCommand`:
 * Sending an empty string when `'PLAYING'`  
   Apparently this silently fails on Discord's end
 * Sending an invalid twitch url when `'STREAMING'`
    This is a leftover from the broadcast eval string -> function migration a while back.