### PR TITLE
 fix(ProfileCommand): add utc offset to the anniversary date 

### DIFF
--- a/src/commands/user/leaderboard.ts
+++ b/src/commands/user/leaderboard.ts
@@ -98,9 +98,10 @@ class LeaderboardCommand extends Command implements IResponsiveEmbedController {
 			if (reaction.me) reaction.users.remove().catch(() => undefined);
 		}
 
-		return message.edit(await (this.handler.resolveCommand('profile') as ProfileCommand)
-			.fetchEmbed({ author: user, guild: message.guild }, pickedUser),
-		);
+		const userEmbed: MessageEmbed = await (this.handler.resolveCommand('profile') as ProfileCommand)
+			.fetchEmbed({ author: user, guild: message.guild }, await user.fetchModel(), pickedUser);
+
+		return message.edit(userEmbed);
 	}
 
 	public async run(

--- a/src/commands/user/profile.ts
+++ b/src/commands/user/profile.ts
@@ -87,7 +87,7 @@ class ProfileCommand extends Command {
 
 		if (typeof userModel.timezone === 'number') {
 			const time: string = moment().utc().add(userModel.timezone, 'hours').format('dddd Do H:mm');
-			const timezone: string | number = userModel.timezone > 0 ? `+${userModel.timezone}` : userModel.timezone;
+			const timezone: string | number = userModel.timezone >= 0 ? `+${userModel.timezone}` : userModel.timezone;
 			userTime = `${time} (UTC ${timezone})`;
 		}
 
@@ -102,13 +102,14 @@ class ProfileCommand extends Command {
 			.addField('Relationship', partnerString, true);
 
 		if (!userModel.partnerHidden && user === author && userModel.partnerId) {
+			const offset: number = authorModel.timezone || 0;
 			const anniversary: string = moment(userModel.partnerSince!)
 				// .utc() because we .add() the utc offset to display the correct date
 				.utc()
-				.add(authorModel.timezone || 0, 'hours')
+				.add(offset, 'hours')
 				.format('YYYY-MM-DD');
 
-			embed.addField('Relationship Anniversary', anniversary, true);
+			embed.addField('Relationship Anniversary', `${anniversary} (UTC ${offset >= 0 ? '+' : ''}${offset})`, true);
 		}
 
 		return embed;


### PR DESCRIPTION
This PR fixes a minor issue with the profile command leading to an incorrect relationship anniversary date.

This is caused by the user in a different time zone than the server where the offset is causing the anniversary date to fall on another date in their timezone.