### PR TITLE
feat(Prometheus): add counters and gauges

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"moment-duration-format": "^2.2.2",
 		"node-fetch": "^2.2.0",
 		"pg": "^7.4.3",
+		"prom-client": "^11.3.0",
 		"raven": "github:spaceeec/raven-node#pg_fix",
 		"reflect-metadata": "^0.1.12",
 		"sequelize": "4.38.0",

--- a/src/Shard.ts
+++ b/src/Shard.ts
@@ -2,7 +2,10 @@
 import 'source-map-support/register';
 
 import { Shard, ShardingManager } from 'discord.js';
+import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { join } from 'path';
+import { AggregatorRegistry, register } from 'prom-client';
+import { parse } from 'url';
 
 import { WebhookLogger } from './structures/WebhookLogger';
 
@@ -28,3 +31,15 @@ manager.on('shardCreate', (shard: Shard) => {
 		.on('error', (error: Error) => webhook.error('Shard Error', shard.id, 'Shard errored:', error))
 		.on('spawn', () => webhook.info('Shard Spawn', shard.id, 'Shard spawned.'));
 });
+
+createServer(async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+	if (parse(req.url!).pathname === '/metrics') {
+		const metrics: object[][] = await manager.broadcastEval('this.getMetrics()');
+		res.writeHead(200, { 'content-type': register.contentType });
+		res.write(AggregatorRegistry.aggregate(metrics).metrics());
+	} else {
+		res.writeHead(404, { 'content-type': register.contentType });
+		res.write('Route not found');
+	}
+	res.end();
+}).listen(9001, () => webhook.info('Prometheus', 'Listening for requests...'));

--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -82,6 +82,9 @@ export class Client extends DJSClient {
 
 		register.setDefaultLabels({ shard_id: shardId });
 
+		// To get a stat here, not simply nothing
+		this.errorCount.inc(0);
+
 		registerListeners(this);
 	}
 

--- a/src/structures/Prometheus.ts
+++ b/src/structures/Prometheus.ts
@@ -1,0 +1,106 @@
+import { execSync } from 'child_process';
+import { Gauge } from 'prom-client';
+
+import { Loggable, Logger } from './Logger';
+
+const TIMEOUT = 10000;
+
+/**
+ * Prometheus Singleton
+ */
+@Loggable('PROMETHEUS')
+export class Prometheus {
+	/**
+	 * Singleton Prometheus instance
+	 */
+	public static get instance(): Prometheus {
+		return this._instance || new this();
+	}
+
+	/**
+	 * Prometheus instance
+	 */
+	private static _instance: Prometheus;
+
+	/**
+	 * Reference to the Logger instance
+	 */
+	private readonly logger!: Logger;
+
+	/**
+	 * Timers currently running;
+	 */
+	private readonly timers: NodeJS.Timer[] = [];
+
+	/** Gauge for the current memory usage */
+	private readonly _memory: Gauge;
+	/** Gauge for the node version */
+	private readonly _nodeVersion: Gauge;
+	/** Gauge for the bot version and commit hash */
+	private readonly _kannaVersion: Gauge;
+
+	private started: boolean = false;
+
+	/**
+	 * Instantiate the Prometheus singleton.
+	 */
+	private constructor() {
+		if (Prometheus._instance) {
+			throw new Error('Can not create multiple instances from Prometheus singleton.');
+		}
+
+		Prometheus._instance = this;
+
+		this._memory = new Gauge({
+			help: 'Memory being used by this process',
+			name: 'kanna_kobayashi_process_rss',
+		});
+
+		this._nodeVersion = new Gauge({
+			help: 'Nodejs version of this process',
+			labelNames: ['version'],
+			name: 'kanna_kobayashi_nodejs_version',
+		});
+
+		this._kannaVersion = new Gauge({
+			help: 'Current version of the bot',
+			labelNames: ['version', 'commit'],
+			name: 'kanna_kobayashi_version',
+		});
+	}
+
+	/**
+	 * Start Prometheus timers
+	 */
+	public start(): void {
+		if (this.started) return;
+		this.started = true;
+
+		this.timers.push(
+			setInterval(() =>
+				this._memory.set(process.memoryUsage().rss, Date.now()), TIMEOUT),
+		);
+		for (const timer of this.timers) timer.unref();
+
+		this._nodeVersion.set({ version: process.versions.node }, 1);
+
+		const { version } = require('../../package.json');
+		const commit = execSync('git rev-parse --short HEAD', { encoding: 'utf8', cwd: __dirname });
+
+		this._kannaVersion.set({ version, commit }, 1);
+
+		this.logger.info('Installed');
+	}
+
+	/**
+	 * Stop Prometheus timers
+	 */
+	public stop(): void {
+		if (!this.started) return;
+		this.started = false;
+
+		for (const timer of this.timers) {
+			clearInterval(timer);
+		}
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 bluebird@^3.4.6, bluebird@^3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
@@ -580,6 +585,13 @@ prism-media@^1.0.0:
   resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.0.1.tgz#3d033c214f9d79ca157bae7985938be65f521c02"
   integrity sha512-Unmeibfk7b8wiiQFPlCC0GgCRaAejSpe2ElgfDkMi9ZmsqzeTbUnmiLNjyqONeKK+HMYINYHOgJFox5l7FU7YA==
 
+prom-client@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.3.0.tgz#fe93f360182f1ec1921722efc211a6c0e68e0253"
+  integrity sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==
+  dependencies:
+    tdigest "^0.1.1"
+
 "raven@github:spaceeec/raven-node#pg_fix":
   version "2.6.2"
   resolved "https://codeload.github.com/spaceeec/raven-node/tar.gz/7d09a19f4b5899d37eced430c636f7bcf908c61d"
@@ -712,6 +724,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 terraformer-wkt-parser@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
This PR adds `prom-client` and adds a bunch of `Counter`s and `Gauge`s for stats:
- [x] Commands
- [x] Gateway Events
- [x] Guild Count
- [x] Errors
- [x] Ram usage
- [x] cpu time
- [x] nodejs version
- [x] kanna (bot) version
