### PR TITLE
Fix/prometheus/cpu usage

### DIFF
--- a/src/structures/Prometheus.ts
+++ b/src/structures/Prometheus.ts
@@ -94,8 +94,9 @@ export class Prometheus {
 			),
 			setInterval(
 				() => {
-					const { user, system } = this._lastCpuUsage = process.cpuUsage(this._lastCpuUsage);
-					this._cpu.set(user + system, Date.now());
+					let oldUsage: number = this._lastCpuUsage.system + this._lastCpuUsage.user;
+					const { user, system } = this._lastCpuUsage = process.cpuUsage();
+					this._cpu.set((user + system) - oldUsage, Date.now());
 				},
 				TIMEOUT,
 			),

--- a/src/structures/Prometheus.ts
+++ b/src/structures/Prometheus.ts
@@ -94,7 +94,7 @@ export class Prometheus {
 			),
 			setInterval(
 				() => {
-					let oldUsage: number = this._lastCpuUsage.system + this._lastCpuUsage.user;
+					const oldUsage: number = this._lastCpuUsage.system + this._lastCpuUsage.user;
 					const { user, system } = this._lastCpuUsage = process.cpuUsage();
 					this._cpu.set((user + system) - oldUsage, Date.now());
 				},


### PR DESCRIPTION
This PR fixes a small bug in the interval reporting the cpu time.
Using the last diff instead of the previous full cpu time caused the reported time to keep growing although the actual time didn't grew (that much).