### PR TITLE
feat(CommandHandler): allow spaces after the prefix (or the lack thereof)

### DIFF
--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -82,7 +82,7 @@ export class CommandHandler {
 			? ['kanna ', 'k!', '-']
 			: ['kanna ', 'k!'];
 
-		client.once('ready', () => this._prefixes.push(`<@!?${this.client.user!.id}> `));
+		client.once('ready', () => this._prefixes.push(`<@!?${this.client.user!.id}>`));
 
 		registerListeners(client, this);
 	}
@@ -336,7 +336,7 @@ export class CommandHandler {
 	private _matchCommand(message: Message, guildModel: GuildModel):
 		[Command, string, string[]] | [undefined, undefined, undefined] {
 		const prefixes: string[] = guildModel.prefix ? this._prefixes.concat(guildModel.prefix) : this._prefixes;
-		const match: RegExpExecArray | null = new RegExp(`^(${prefixes.join('|')})`, 'i').exec(message.content);
+		const match: RegExpExecArray | null = new RegExp(`^(${prefixes.join(' *|')})`, 'i').exec(message.content);
 
 		if (!match) return [undefined, undefined, undefined];
 


### PR DESCRIPTION
This PR adds a small ux enhancement allowing the usage of space(s) between the prefix and the command (or the lack thereof)

Previously the only valid usage:
`k!ping` (NO space allowed)
`@Kanna Kobayashi ping` (must be ONE space)

With this PR any amount (or none) is valid:
`k!     ping`
`@Kanna Kobayashiping`

This could be particularly be useful for mobile users as mobile phones tend to automatically add after known phrases (which the prefix might be)