### PR TITLE
fix(ChooseCommand): only split on expected delimiters, filter empty results

### DIFF
--- a/src/commands/fun/choose.ts
+++ b/src/commands/fun/choose.ts
@@ -25,8 +25,10 @@ class ChooseCommand extends Command
 		if (!args.length) return `you have to give me something to choose from! (\`${this.usage}\`)`;
 
 		const joined: string = args.join(' ');
-		const options: string[] = /\||or|,/ig.test(joined)
-			? joined.replace(/\s*(\||or|,)\s*/ig, ' ').split(' ')
+		// Match separated pipes, `or` as a word, or a comma after a word followed by space (surrouned by whitespace)
+		const regex: RegExp = /\s*(?: \| |\bor\b|\b,)\s*/ig;
+		const options: string[] = regex.test(joined)
+			? joined.split(regex).filter(e => e)
 			: args;
 
 		if (!options.length) return `you have to give me something to choose from! (\`${this.usage}\`)`;


### PR DESCRIPTION
This PR fixes #65 splitting only on expected delimiters and filtering out empty results.
`memory` is no longer being split, `memory , test or memory, test` will result in `['memory , test', 'memory', 'test']`, etc.

`memory, or not` will no longer result in `['memory', '', 'not']` (the empty string is now no longer there)
