### PR TITLE
fix(LookupCommand): show the guild of the invite, if present, disallow gdm invites

### DIFF
--- a/src/commands/info/guild.ts
+++ b/src/commands/info/guild.ts
@@ -1,6 +1,7 @@
-import { Collection, Message, Role, Snowflake } from 'discord.js';
+import { Collection, Guild, Message, Role, Snowflake } from 'discord.js';
 import * as moment from 'moment';
 
+import { User as UserModel } from '../../models/User';
 import { Command } from '../../structures/Command';
 import { CommandHandler } from '../../structures/CommandHandler';
 import { MessageEmbed } from '../../structures/MessageEmbed';
@@ -23,7 +24,14 @@ class GuildInfoCommand extends Command
 
 	public async run(message: GuildMessage, _: string[], { authorModel }: ICommandRunInfo): Promise<Message | Message[]>
 	{
-		const { guild }: GuildMessage = message;
+		const embed: MessageEmbed = await this.getEmbed(message, message.guild, authorModel);
+
+		return message.channel.send(embed);
+	}
+
+
+	public async getEmbed(message: GuildMessage, guild: Guild, authorModel: UserModel): Promise<MessageEmbed>
+	{
 		if (guild.memberCount > guild.members.size) await guild.members.fetch();
 
 		const roles: Collection<Snowflake, Role> = new Collection(guild.roles.entries());
@@ -100,7 +108,7 @@ class GuildInfoCommand extends Command
 			.addField('Roles', rolesString || 'None', true)
 			.addField('Emojis', emojis || 'None', true);
 
-		return message.channel.send(embed);
+		return embed;
 	}
 }
 

--- a/src/commands/info/lookup.ts
+++ b/src/commands/info/lookup.ts
@@ -39,7 +39,7 @@ class LookupCommand extends Command
 		}
 		catch
 		{
-			return 'I could\'t find a valid invite for this link or code.';
+			return 'I couldn\'t find a valid invite for this link or code.';
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #64 showing the actually resolved guild instead of the current one when an invite to a guild handled by the current shard is used.

This PR also disallows group dm channel invites to be used (not a guild after all).

<!--
	Before opening this pull request, verify if your code works.
	Have in mind what is said in the CONTRIBUTING.md file in mind.
	
	Always add a brief summary of what is being changed/added/removed in this PR.
	If your Pull Request is not self-explanatory it will make things harder for all of us.
-->
