### PR TITLE
fix(InteractiveCommands): call parent parseArgs to take care of blocks

### DIFF
--- a/src/commands/interactive/blush.ts
+++ b/src/commands/interactive/blush.ts
@@ -26,14 +26,12 @@ class BlushCommand extends WeebCommand
 	public async parseArgs(
 		message: GuildMessage,
 		args: string[],
+		commandInfo: ICommandRunInfo,
 	): Promise<string | [Collection<Snowflake, IWeebResolvedMember> | undefined]>
 	{
 		if (!args.length) return [undefined];
 
-		const members: Collection<Snowflake, IWeebResolvedMember> = await this.resolveMembers(args, message);
-		if (!members.size) return `I could not find anyone with ${args.join(' ')}`;
-
-		return [members];
+		return super.parseArgs(message, args, commandInfo);
 	}
 
 	public async run(

--- a/src/commands/interactive/cry.ts
+++ b/src/commands/interactive/cry.ts
@@ -26,14 +26,13 @@ class CryCommand extends WeebCommand
 	public async parseArgs(
 		message: GuildMessage,
 		args: string[],
+		commandInfo: ICommandRunInfo,
 	): Promise<string | [Collection<Snowflake, IWeebResolvedMember> | undefined]>
 	{
 		if (!args.length) return [undefined];
 
-		const members: Collection<Snowflake, IWeebResolvedMember> = await this.resolveMembers(args, message);
-		if (!members.size) return `I could not find anyone with ${args.join(' ')}`;
+		return super.parseArgs(message, args, commandInfo);
 
-		return [members];
 	}
 
 	public async run(

--- a/src/commands/interactive/dance.ts
+++ b/src/commands/interactive/dance.ts
@@ -25,14 +25,12 @@ class DanceCommand extends WeebCommand
 	public async parseArgs(
 		message: GuildMessage,
 		args: string[],
+		commandInfo: ICommandRunInfo,
 	): Promise<string | [Collection<Snowflake, IWeebResolvedMember> | undefined]>
 	{
 		if (!args.length) return [undefined];
 
-		const members: Collection<Snowflake, IWeebResolvedMember> = await this.resolveMembers(args, message);
-		if (!members.size) return `I could not find anyone with ${args.join(' ')}`;
-
-		return [members];
+		return super.parseArgs(message, args, commandInfo);
 	}
 
 	public async run(


### PR DESCRIPTION
This PR fixes #54 making the interactive commands which implement their own `parseArgs` function to call the parent one when args were provided.
