### PR TITLE
fix(SaydCommand): do not delete already deleted message, handle unkown_message error

### DIFF
--- a/src/commands/fun/sayd.ts
+++ b/src/commands/fun/sayd.ts
@@ -1,9 +1,10 @@
-import { Message } from 'discord.js';
+import { Constants, Message } from 'discord.js';
 
 import { Command } from '../../structures/Command';
 import { CommandHandler } from '../../structures/CommandHandler';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
+import { catchErrors } from '../../util/Util';
 
 class SayDeleteCommand extends Command
 {
@@ -25,12 +26,14 @@ class SayDeleteCommand extends Command
 		return [message.cleanContent.slice(message.cleanContent.indexOf(commandName) + commandName.length)];
 	}
 
-	public run(message: GuildMessage, [content]: string[]): Promise<[Message, Message | Message[]]>
+	public async run(message: GuildMessage, [content]: string[]): Promise<Message | Message[]>
 	{
-		return Promise.all([
-			message.delete(),
-			message.channel.send(content),
-		]);
+		if (!message.deleted)
+		{
+			await message.delete().catch(catchErrors(Constants.APIErrors.UNKNOWN_MESSAGE));
+		}
+
+		return message.channel.send(content);
 	}
 }
 

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -1,4 +1,4 @@
-import { Collection } from 'discord.js';
+import { Collection, Constants, DiscordAPIError } from 'discord.js';
 
 /**
  * Title case the passed input string.
@@ -218,3 +218,24 @@ const durationModifiers: { [key: string]: number } = {
  * @returns A duration in seconds
  */
 export const resolveDuration: (value: string) => number = _resolve.bind(null, durationRegex, durationModifiers);
+
+// Is there no builtin type for this?
+type ObjectValueType<T> = T extends { [key: string]: infer P } ? P : never
+
+/**
+ * High-order function catching certain DiscordAPIErrors and return them, rather than rethrowing them.
+ * @param errors Error codes to catch
+ * @returns "catch" function to be used within a `Promise#catch`.
+ */
+export function catchErrors(...errors: ObjectValueType<Constants['APIErrors']>[]): (reason: any) => DiscordAPIError
+{
+	return (reason: any): DiscordAPIError =>
+	{
+		if (reason instanceof DiscordAPIError && (errors as number[]).includes(reason.code))
+		{
+			return reason;
+		}
+
+		throw reason;
+	};
+}


### PR DESCRIPTION
This PR fixes #77 by checking whether the message was already `deleted` and ignore `UNKNOWN_MESSAGE` errors due to race conditions with the previously mentioned property.