### PR TITLE
typo(CommandHandler): fix spelling of 'error'

### DIFF
--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -357,7 +357,7 @@ export class CommandHandler
 
 				this.client.webhook.error('CommandError', message.guild.shardID, error);
 				message.reply(
-					'**an errror occured, but rest assured! It has already been reported and will be fixed in no time!**',
+					'**an error occured, but rest assured! It has already been reported and will be fixed in no time!**',
 				).catch(() => null);
 			}
 		}


### PR DESCRIPTION
This PR fixes #76 by fixing the typo.