### PR TITLE
fix(CatchCommand): handle the special case of 1 bug

### DIFF
--- a/src/commands/fun/catch.ts
+++ b/src/commands/fun/catch.ts
@@ -48,7 +48,21 @@ class CatchCommand extends Command
 			bugAmount = 1;
 		}
 
-		return message.channel.send(`You ${bugAmount ? `got **${bugAmount}** bugs! 🐛` : 'did not get any bugs...'}`);
+		let response: string;
+		if (bugAmount === 0)
+		{
+			response = 'You did not get any bugs...';
+		}
+		else if (bugAmount === 1)
+		{
+			response = 'You got 1 bug! 🐛';
+		}
+		else
+		{
+			response = `You got ${bugAmount} bugs! 🐛`;
+		}
+
+		return message.channel.send(response);
 	}
 }
 


### PR DESCRIPTION
This PR fixes #75 by handling the case of `bugAmount === 1`.

The code was extracted to a separate variable and an if / else if chain in order to keep the code comprehensible.