### PR TITLE
fix(BotLists): only report guild count from shard 0

### DIFF
--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -124,7 +124,7 @@ export class Client extends DJSClient
 	@RavenContext
 	protected _onceReady(): void
 	{
-		if (this.user!.id === '297459926505095180')
+		if (this.user!.id === '297459926505095180' && this.shard!.ids.includes(0))
 		{
 			this.setInterval(updateBotLists.bind(this), 30 * 60 * 1000);
 		}

--- a/src/util/botlists.ts
+++ b/src/util/botlists.ts
@@ -22,7 +22,7 @@ export async function updateBotLists(this: Client): Promise<void>
 		.then((res: number[]) => res.reduce((p: number, c: number) => p + c));
 
 	// No webhook, that would just spam
-	Logger.instance.debug('BotLists', `Updating guild count for bot lists to ${count} guilds.`);
+	Logger.instance.debug('BotLists', this.shard!.ids[0], `Updating guild count for bot lists to ${count} guilds.`);
 
 	/* eslint-disable-next-line @typescript-eslint/camelcase */
 	const data: { server_count: number } = { server_count: count };


### PR DESCRIPTION
The check ensuring that only one shard (0 in this case) reports back to botlists was removed at some point. Reintroducing it here.