### PR TITLE
fix: delete unused messages from cache, not from Discord

### DIFF
--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -263,7 +263,7 @@ export class Client extends DJSClient
 			|| !reaction.message.embeds[0].footer
 		)
 		{
-			reaction.message.channel.messages.delete(reaction.message.id);
+			reaction.message.channel.messages.cache.delete(reaction.message.id);
 
 			return;
 		}
@@ -278,7 +278,7 @@ export class Client extends DJSClient
 			.exec(reaction.message.embeds[0].footer.text!) ?? [];
 		if (!tag || !name)
 		{
-			reaction.message.channel.messages.delete(reaction.message.id);
+			reaction.message.channel.messages.cache.delete(reaction.message.id);
 
 			return;
 		}
@@ -286,7 +286,7 @@ export class Client extends DJSClient
 		const command: IResponsiveEmbedController = this.commandHandler.resolveCommand(name.toLowerCase()) as any;
 		if (!command)
 		{
-			reaction.message.channel.messages.delete(reaction.message.id);
+			reaction.message.channel.messages.cache.delete(reaction.message.id);
 
 			return;
 		}
@@ -294,7 +294,7 @@ export class Client extends DJSClient
 		if (user.tag !== tag || !command.emojis || !command.onCollect
 			|| !command.emojis.includes(reaction.emoji.name))
 		{
-			reaction.message.channel.messages.delete(reaction.message.id);
+			reaction.message.channel.messages.cache.delete(reaction.message.id);
 
 			return;
 		}

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -219,7 +219,7 @@ export class CommandHandler
 		{
 			this.client.channels.cache.delete(message.channel.id);
 			await message.channel.delete().catch(() => null);
-			message.channel.messages.delete(message.id);
+			message.channel.messages.cache.delete(message.id);
 
 			return;
 		}
@@ -227,7 +227,7 @@ export class CommandHandler
 		// Ignore system messages
 		if (message.system)
 		{
-			message.channel.messages.delete(message.id);
+			message.channel.messages.cache.delete(message.id);
 
 			return;
 		}
@@ -365,7 +365,7 @@ export class CommandHandler
 		}
 		finally
 		{
-			message.channel.messages.delete(message.id);
+			message.channel.messages.cache.delete(message.id);
 		}
 	}
 


### PR DESCRIPTION
One small but fatal oversight from #84, causing all unused messages to be deleted on Discord and not just from cache.

This will only delete them locally and note remotely too.