### PR TITLE
fix: use Structures from discord.js in order to properly extend user and guild

### DIFF
--- a/src/extensions/Extension.ts
+++ b/src/extensions/Extension.ts
@@ -22,6 +22,8 @@ export async function extendAll(): Promise<void>
 		} = require(`./${file}`);
 		/* eslint-enable */
 
+		if (!Extension || !Target) continue;
+
 		Object.defineProperties(
 			Target.prototype,
 			Object.getOwnPropertyDescriptors(Extension.prototype),
@@ -31,17 +33,20 @@ export async function extendAll(): Promise<void>
 
 declare module 'discord.js' {
 	/* eslint-disable @typescript-eslint/interface-name-prefix */
-	interface Guild {
+	interface Guild
+	{
 		model: GuildModel;
 
 		fetchModel(): Promise<GuildModel>;
 	}
 
-	interface User {
+	interface User
+	{
 		fetchModel(): Promise<UserModel>;
 	}
 
-	interface ShardClientUtil {
+	interface ShardClientUtil
+	{
 		broadcastEval<T, U extends Client>(fn: (client: U) => T,
 		): T extends Promise<any>
 			? T extends Promise<infer U> ? U : any

--- a/src/extensions/Guild.ts
+++ b/src/extensions/Guild.ts
@@ -1,18 +1,22 @@
-import { Guild } from 'discord.js';
+import { Structures } from 'discord.js';
 
 import { Guild as GuildModel } from '../models/Guild';
 
-class GuildExtension
-{
-	public async fetchModel(this: Guild): Promise<GuildModel>
+
+const GuildExtensionClass = Structures.extend('Guild', Guild =>
+	class GuildExtension extends Guild
 	{
-		if (this.model) return this.model;
+		public model!: GuildModel;
 
-		[this.model] = await GuildModel.findCreateFind<GuildModel>({ where: { id: this.id } });
+		public async fetchModel(): Promise<GuildModel>
+		{
+			if (this.model) return this.model;
 
-		return this.model;
+			[this.model] = await GuildModel.findCreateFind<GuildModel>({ where: { id: this.id } });
+
+			return this.model;
+		}
 	}
-}
+);
 
-export { GuildExtension as Extension };
-export { Guild as Target };
+export { GuildExtensionClass as Guild };

--- a/src/extensions/User.ts
+++ b/src/extensions/User.ts
@@ -1,21 +1,16 @@
-import { Message, User } from 'discord.js';
+import { Structures } from 'discord.js';
 
 import { User as UserModel } from '../models/User';
 
-class UserExtension
-{
-	public fetchModel(this: User): Promise<UserModel>
+
+const UserExtensionClass = Structures.extend('User', User =>
+	class UserExtension extends User
 	{
-		return UserModel.fetch(this.id);
+		public fetchModel(): Promise<UserModel>
+		{
+			return UserModel.fetch(this.id);
+		}
 	}
+);
 
-	/* eslint-disable @typescript-eslint/no-empty-function */
-	set lastMessage(value: Message)
-	{ }
-	set lastMessageID(value: string)
-	{ }
-	/* eslint-enable @typescript-eslint/no-empty-function */
-}
-
-export { UserExtension as Extension };
-export { User as Target };
+export { UserExtensionClass as User };


### PR DESCRIPTION
Something in discord.js' internals changed and this hack no longer works.
So it's about time to use discord.js' API for this.