### PR TITLE
fix(SetGameCommand): actually publish the activity and only set it on the last shard

### DIFF
--- a/src/commands/unique/setgame.ts
+++ b/src/commands/unique/setgame.ts
@@ -52,6 +52,8 @@ class SetGameCommand extends Command
 			this.activity = { type: 'PLAYING', name: args.join(' ') };
 		}
 
+		await this.publishActivity();
+
 		return message.channel.send('Updated presence activity successfully on all shards!');
 	}
 

--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -129,10 +129,13 @@ export class Client extends DJSClient
 
 		this.webhook.info(`ClientReady [${id}]`, id, 'Logged in and processing events!');
 
-		// Set the activity on startup
-		const setGameCommand: SetGameCommand = this.commandHandler.resolveCommand('setgame') as SetGameCommand;
-		await setGameCommand.cleanup();
-		await setGameCommand.publishActivity();
+		if (id + 1 === this.options.shardCount)
+		{
+			// Set the activity on startup
+			const setGameCommand: SetGameCommand = this.commandHandler.resolveCommand('setgame') as SetGameCommand;
+			await setGameCommand.cleanup();
+			await setGameCommand.publishActivity();
+		}
 	}
 
 	@once('ready')


### PR DESCRIPTION
This PR fixes a small oversight of mine causing the presence to not actually be set when using the setgame command.

This also changes the startup presence to be only set on the last shard.