### PR TITLE
fix(RestartCommand): use process messages instead of broadcast eval

### DIFF
--- a/src/types/IPCMessageType.ts
+++ b/src/types/IPCMessageType.ts
@@ -1,0 +1,4 @@
+export enum IPCMessageType {
+	RESTART,
+	RESTART_ALL,
+}


### PR DESCRIPTION
This PR shifts `RestartCommand` away from using `ShardClientUtil#broadcastEval` in favor of `ShardClientUtil#send`.

The reason for this is that the former waits for a response that will never come, as the shard's process exited before being able to respond, causing the promise of broadcastEval to never resolve and subsequently causing a (probably negligible) memory leak.