### PR TITLE
fix: wrap parameter in parentheses to fix broadcast eval

### DIFF
--- a/src/commands/unique/setgame.ts
+++ b/src/commands/unique/setgame.ts
@@ -93,7 +93,7 @@ class SetGameCommand extends Command
 
 	private async guildCount(): Promise<ActivityOptions>
 	{
-		const totalGuilds: number = await this.client.shard!.broadcastEval(client => client.guilds.cache.size)
+		const totalGuilds: number = await this.client.shard!.broadcastEval((client: Client) => client.guilds.cache.size)
 			.then((result: number[]) => result.reduce((acc: number, current: number) => acc + current));
 
 		return { type: 'PLAYING', name: `k!help | on ${totalGuilds} guilds` };

--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -175,7 +175,7 @@ export class Client extends DJSClient
 
 		if (!left && guild.memberCount !== guild.members.cache.size) await guild.members.fetch();
 
-		const totalGuilds: number = await this.shard!.broadcastEval(client => client.guilds.cache.size)
+		const totalGuilds: number = await this.shard!.broadcastEval((client: Client) => client.guilds.cache.size)
 			.then((result: number[]) => result.reduce((acc: number, current: number) => acc + current));
 		const blacklisted: string = await UserModel.fetch(guild.ownerID)
 			.then((user: UserModel) => user.type === UserTypes.BLACKLISTED ? 'Yes' : 'No');

--- a/src/util/botlists.ts
+++ b/src/util/botlists.ts
@@ -18,7 +18,7 @@ const DBotsOrg: () => APIRouter = buildRouter({
 
 export async function updateBotLists(this: Client): Promise<void>
 {
-	const count: number = await this.shard!.broadcastEval(client => client.guilds.cache.size)
+	const count: number = await this.shard!.broadcastEval((client: Client) => client.guilds.cache.size)
 		.then((res: number[]) => res.reduce((p: number, c: number) => p + c));
 
 	// No webhook, that would just spam


### PR DESCRIPTION
Due to some hackery allowing functions with parameters, those parameters need to be wrapped in parentheses, this PR adds those.