### PR TITLE
refactor(logging): set process tag internally

### DIFF
--- a/src/Shard.ts
+++ b/src/Shard.ts
@@ -11,9 +11,9 @@ import { WebhookLogger } from './structures/WebhookLogger';
 import { IPCMessageType } from './types/IPCMessageType';
 
 const webhook: WebhookLogger = WebhookLogger.instance;
-webhook.info('Manager Spawn', 'Manager', 'Manager spawned.');
+webhook.info('Manager Spawn', 'Manager spawned.');
 
-process.on('unhandledRejection', (error: {} | null | undefined) => webhook.error('REJECTION', 'Manager', error));
+process.on('unhandledRejection', (error: {} | null | undefined) => webhook.error('REJECTION', error));
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { clientToken: token, httpPort }: { clientToken: string; httpPort: number } = require('../data');
@@ -26,7 +26,8 @@ manager.spawn(manager.totalShards, 5500, Infinity);
 
 manager.on('shardCreate', (shard: Shard) =>
 {
-	webhook.info('Shard Create', shard.id, 'Shard created.');
+	const shardID: number = shard.id;
+	webhook.info(`Shard Create [${shardID}]`, 'Shard created.');
 	shard
 		.on('message', message =>
 		{
@@ -41,7 +42,7 @@ manager.on('shardCreate', (shard: Shard) =>
 					}
 					else
 					{
-						webhook.warn('IPCMESSAGE', 'Manager', `Received a restart request for an unknown shard: ${message.target}`);
+						webhook.warn(`IPCMESSAGE [${shardID}]`, `Received a restart request for an unknown shard: ${message.target}`);
 					}
 					break;
 				}
@@ -51,13 +52,13 @@ manager.on('shardCreate', (shard: Shard) =>
 					break;
 
 				default:
-					webhook.warn('IPCMESSAGE', 'Manager', `Received an unexpected message type: ${message.type}`);
+					webhook.warn(`IPCMESSAGE [${shardID}]`, `Received an unexpected message type: ${message.type}`);
 					break;
 			}
 		})
-		.on('death', () => webhook.warn('Shard Death', shard.id, 'Shard died.'))
-		.on('error', (error: Error) => webhook.error('Shard Error', shard.id, 'Shard errored:', error))
-		.on('spawn', () => webhook.warn('Shard Spawn', shard.id, 'Shard spawned.'));
+		.on('death', () => webhook.warn(`Shard Death [${shardID}]`, 'Shard died.'))
+		.on('error', (error: Error) => webhook.error(`Shard Error [${shardID}]`, 'Shard errored:', error))
+		.on('spawn', () => webhook.warn(`Shard Spawn [${shardID}]`, 'Shard spawned.'));
 });
 
 createServer(async (req: IncomingMessage, res: ServerResponse): Promise<void> =>
@@ -78,10 +79,10 @@ createServer(async (req: IncomingMessage, res: ServerResponse): Promise<void> =>
 	}
 	catch (e)
 	{
-		webhook.error('Prometheus', 'Manager', e);
+		webhook.error('Prometheus', e);
 
 		res.writeHead(500, { 'content-type': register.contentType });
 		res.write('Internal Server Error');
 	}
 	res.end();
-}).listen(httpPort, () => webhook.info('Prometheus', 'Manager', 'Listening for requests...'));
+}).listen(httpPort, () => webhook.info('Prometheus', 'Listening for requests...'));

--- a/src/decorators/LoggerDecorator.ts
+++ b/src/decorators/LoggerDecorator.ts
@@ -2,7 +2,7 @@
 import { Logger } from '../structures/Logger';
 import { LogLevel } from '../types/LogLevel';
 
-function getHandler(prefix: string | undefined): ProxyHandler<Logger>
+function getHandler(prefix: string): ProxyHandler<Logger>
 {
 	return {
 		get: (target: Logger, prop: keyof Logger): (...data: any[]) => Promise<void> | void =>

--- a/src/extensions/ShardClientUtil.ts
+++ b/src/extensions/ShardClientUtil.ts
@@ -1,13 +1,13 @@
 import { Client, ShardClientUtil, Util } from 'discord.js';
 import { inspect } from 'util';
-import { Loggable, Logger } from '../structures/Logger';
+import { Loggable, AttachedLogger } from '../structures/Logger';
 
 const broadcastEval: (script: string) => Promise<any[]> = ShardClientUtil.prototype.broadcastEval;
 
 @Loggable('BROADCASTEVAL')
 class ShardClientUtilExtension
 {
-	private logger!: Logger;
+	private logger!: AttachedLogger;
 
 	public async _handleMessage(
 		this: { _respond: (type: string, val: object) => void; client: any },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ import 'source-map-support/register';
 
 // Hack to ensure that the WebhookLogger is instantiated first
 import { WebhookLogger } from './structures/WebhookLogger';
-const shardID = parseInt(process.env.SHARDS!);
-WebhookLogger.instance.warn(`Process spawn [${shardID}]`, shardID, 'Process spawned');
+WebhookLogger.instance.warn(`Process spawn [${parseInt(process.env.SHARDS!)}]`, 'Process spawned');
 
 import { config } from 'raven';
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/src/scripts/buildItems.ts
+++ b/src/scripts/buildItems.ts
@@ -12,7 +12,7 @@ PostgreSQL.instance.start().then(async () =>
 			Logger.instance.error('ERROR', error);
 			process.exit(1);
 		});
-	Logger.instance.info('SUCESS', 'Created the badges.');
+	Logger.instance.info('SUCESS', 'Created all badges.');
 
 	return process.exit(0);
 });

--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -116,7 +116,7 @@ export class Client extends DJSClient
 			logMessage += `\nThere were ${unavailableGuilds.size} unavailable guilds.`;
 		}
 
-		this.webhook.info(`ShardReady [${id}]`, id, logMessage);
+		this.webhook.info(`ShardReady [${id}]`, logMessage);
 	}
 
 	@on('ready')
@@ -127,7 +127,7 @@ export class Client extends DJSClient
 
 		this._guildCount.set(this.guilds.cache.size);
 
-		this.webhook.info(`ClientReady [${id}]`, id, 'Logged in and processing events!');
+		this.webhook.info(`ClientReady [${id}]`, 'Logged in and processing events!');
 
 		if (id + 1 === this.options.shardCount)
 		{
@@ -153,7 +153,7 @@ export class Client extends DJSClient
 	protected _onDisconnect({ code, reason }: { code: number; reason: string }, id: number): void
 	{
 		// Only for fatal disconnects, should never happen.
-		this.webhook.error(`shardDisconnect [${id}]`, id, `Code: \`${code}\`\nReason: \`${reason || 'No reason available'}\``);
+		this.webhook.error(`shardDisconnect [${id}]`, `Code: \`${code}\`\nReason: \`${reason || 'No reason available'}\``);
 	}
 
 	@on('shardError')
@@ -162,7 +162,7 @@ export class Client extends DJSClient
 	{
 		this.errorCount.inc({ type: 'WebSocket' });
 
-		this.webhook.error(`ShardError [${id}]`, id, error);
+		this.webhook.error(`ShardError [${id}]`, error);
 	}
 
 	@on('guildCreate', false)
@@ -272,8 +272,7 @@ export class Client extends DJSClient
 				// Ignore Unknown Message errors
 				if (e.code === 10008) return;
 				this.errorCount.inc({ type: 'Reaction' });
-				const shardID = reaction.message.guild!.shardID;
-				this.webhook.error(`ReactionError [${shardID}]`, shardID, e);
+				this.webhook.error(`ReactionError [${reaction.message.guild!.shardID}]`, e);
 
 				return;
 			}
@@ -326,7 +325,7 @@ export class Client extends DJSClient
 	@RavenContext
 	protected _onReconnecting(id: number): void
 	{
-		this.webhook.info(`Reconnecting [${id}]`, id, 'Shard is reconnecting...');
+		this.webhook.info(`Reconnecting [${id}]`, 'Shard is reconnecting...');
 	}
 
 	@on('warn')
@@ -334,7 +333,7 @@ export class Client extends DJSClient
 	protected _onWarn(warning: string): void
 	{
 		const id = this.shard!.ids[0]!;
-		this.webhook.warn(`Client Warn [${id}]`, id, warning);
+		this.webhook.warn(`Client Warn [${id}]`, warning);
 	}
 
 	@on('debug')
@@ -350,31 +349,31 @@ export class Client extends DJSClient
 		// Discord requested a reconnect
 		if (exec = /\s*\[RECONNECT\]\s*(.+)\s*/.exec(info2))
 		{
-			this.webhook.info(`Reconnect [${id}]`, id, exec[1]);
+			this.webhook.info(`Reconnect [${id}]`, exec[1]);
 		}
 
 		// Discord invalidated our session somehow
 		if (exec = /\s*\[INVALID SESSION\]\s*(.+)\s*/.exec(info2))
 		{
-			this.webhook.warn(`Invalid Session [${id}]`, id, exec[1]);
+			this.webhook.warn(`Invalid Session [${id}]`, exec[1]);
 		}
 
 		// Identifying as a new session
 		if (exec = /\s*\[IDENTIFY\]\s*(.+)\s*/.exec(info2))
 		{
-			this.webhook.warn(`Identify [${id}]`, id, exec[1]);
+			this.webhook.warn(`Identify [${id}]`, exec[1]);
 		}
 
 		// Resuming an existing session after reconnecting
 		if (exec = /\s*\[RESUME\]\s*(.+)\s*/.exec(info2))
 		{
-			this.webhook.warn(`Resume [${id}]`, id, exec[1]);
+			this.webhook.warn(`Resume [${id}]`, exec[1]);
 		}
 
 		// discord.js fetched new session limit informations
 		if (exec = /^Session Limit Information\s*\n\s*Total:\s*(.+)\s*\n\s*Remaining:\s*(.+)/.exec(info2))
 		{
-			this.webhook.info(`Session Limit Information [${id}]`, id, 'Identifies:', exec[2], '/', exec[1]);
+			this.webhook.info(`Session Limit Information [${id}]`, 'Identifies:', exec[2], '/', exec[1]);
 
 			return;
 		}
@@ -382,7 +381,7 @@ export class Client extends DJSClient
 		// The websocket closed for some reason
 		if (exec = /^\[CLOSE\]\s*\n\s*Event Code\s*:\s*(.+)\s*\n\s*Clean\s*:\s*(.+)\s*\n\s*Reason\s*:\s*(.+)/.exec(info2))
 		{
-			this.webhook.info(`WebSocket was closed [${id}]`, id, 'Code:', exec[1], ' Clean:', exec[2], ' Reason:', exec[3]);
+			this.webhook.info(`WebSocket was closed [${id}]`, 'Code:', exec[1], ' Clean:', exec[2], ' Reason:', exec[3]);
 
 			return;
 		}

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -24,7 +24,7 @@ import { isGuildMessage } from '../types/GuildMessage';
 import { UserTypes } from '../types/UserTypes';
 import { Client } from './Client';
 import { Command } from './Command';
-import { Logger } from './Logger';
+import { AttachedLogger } from './Logger';
 import { MessageEmbed } from './MessageEmbed';
 import { Resolver } from './Resolver';
 
@@ -71,7 +71,7 @@ export class CommandHandler
 	/**
 	 * Reference to the logger
 	 */
-	private readonly logger!: Logger;
+	private readonly logger!: AttachedLogger;
 
 	/**
 	 * Instantiate a new command handler
@@ -357,7 +357,7 @@ export class CommandHandler
 					},
 				});
 
-				this.client.webhook.error('CommandError', message.guild.shardID, error);
+				this.client.webhook.error('CommandError', error);
 				message.reply(
 					'**an error occured, but rest assured! It has already been reported and will be fixed in no time!**',
 				).catch(() => null);

--- a/src/structures/PostgreSQL.ts
+++ b/src/structures/PostgreSQL.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { Sequelize } from 'sequelize-typescript';
 
-import { Loggable, Logger } from './Logger';
+import { Loggable, AttachedLogger } from './Logger';
 
 /**
  * Singleton PostgreSQL connection
@@ -30,7 +30,7 @@ export class PostgreSQL
 	/**
 	 * Reference to the Logger instance
 	 */
-	private readonly logger!: Logger;
+	private readonly logger!: AttachedLogger;
 
 	/**
 	 * Instantiate the PostgreSQL singleton.

--- a/src/structures/Prometheus.ts
+++ b/src/structures/Prometheus.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import { Gauge } from 'prom-client';
 
-import { Loggable, Logger } from './Logger';
+import { Loggable, AttachedLogger } from './Logger';
 
 const TIMEOUT = 10000;
 
@@ -27,7 +27,7 @@ export class Prometheus
 	/**
 	 * Reference to the Logger instance
 	 */
-	private readonly logger!: Logger;
+	private readonly logger!: AttachedLogger;
 
 	/**
 	 * Timers currently running;

--- a/src/structures/WebhookLogger.ts
+++ b/src/structures/WebhookLogger.ts
@@ -25,19 +25,12 @@ export class WebhookLogger extends Logger
 		super._write(level, `Webhook][${tag}`, data);
 		if (this._webhookLevel < level) return;
 
-		let shardId: string | null = null;
-		[data, shardId] = typeof data[0] === 'number'
-			? [data.slice(1), `Shard ${data[0]}`]
-			: data[0] === 'Manager'
-				? [data.slice(1), data[0]]
-				: [data, 'Global'];
-
 		const cleaned: string = this._prepareText(data);
 
 		const embed: MessageEmbed = new MessageEmbed()
 			.setTimestamp()
 			.setColor(colors[level][2])
-			.setFooter(shardId);
+			.setFooter(this._processTag);
 		const options: WebhookMessageOptions = {
 			avatarURL: 'https://cdn.discordapp.com/attachments/250372608284033025/494249449862725632/avatar.png',
 			embeds: [embed],

--- a/src/util/botlists.ts
+++ b/src/util/botlists.ts
@@ -22,7 +22,7 @@ export async function updateBotLists(this: Client): Promise<void>
 		.then((res: number[]) => res.reduce((p: number, c: number) => p + c));
 
 	// No webhook, that would just spam
-	Logger.instance.debug('BotLists', this.shard!.ids[0], `Updating guild count for bot lists to ${count} guilds.`);
+	Logger.instance.debug('BotLists', `Updating guild count for bot lists to ${count} guilds.`);
 
 	/* eslint-disable-next-line @typescript-eslint/camelcase */
 	const data: { server_count: number } = { server_count: count };
@@ -39,6 +39,6 @@ export async function updateBotLists(this: Client): Promise<void>
 			tags: { service: 'dbotsorg' },
 		});
 
-		this.webhook.error('dbotsorg', 'Failed updating guild count:');
+		this.webhook.error('dbotsorg', 'Failed updating guild count:', error);
 	}
 }


### PR DESCRIPTION
This PR removes the need to pass a "process tag" to the functions of `Logger` by setting it internally depending on whether the current process is the sharding manager or a shard process.
