### PR TITLE
chore: bump version to v4.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 	</p>
 	<p align="center">
 		<a href="https://github.com/Hydractify/kanna_kobayashi/blob/stable/package.json#L3">
-			<img src="https://img.shields.io/badge/kanna_kobayashi-v4.6.2-fcbbd5.svg?style=flat-square" />
+			<img src="https://img.shields.io/badge/kanna_kobayashi-v4.6.3-fcbbd5.svg?style=flat-square" />
 		</a>
 		<a href="https://www.hydractify.org/discord">
 			<img src="https://img.shields.io/discord/298969150133370880.svg?style=flat-square&logo=discord">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kanna-kobayashi",
-	"version": "4.6.2",
+	"version": "4.6.3",
 	"description": "A community driven open-source application bot for Discord.",
 	"main": "bin/Shard.js",
 	"dependencies": {


### PR DESCRIPTION
This PR bumps the version to v4.6.3.
