### PR TITLE
fix(CryCommand): correctly make the trusted user bold when triggered

### DIFF
--- a/src/commands/interactive/cry.ts
+++ b/src/commands/interactive/cry.ts
@@ -44,7 +44,7 @@ class CryCommand extends WeebCommand
 		const embed: MessageEmbed = await this.fetchEmbed(message, authorModel, members, {
 			bot: 'W-what did I do?!',
 			dev: `What did you do **${members ? members.first()!.name : undefined}**!?`,
-			trusted: `Why **${members ? members.first()!.name : undefined}?`,
+			trusted: `Why **${members ? members.first()!.name : undefined}**?`,
 		});
 
 		if (!members)


### PR DESCRIPTION
This pull request fixes a problem regarding the `CryCommand` where whenever a trusted user gets mentioned their name is not bold as intended.