### PR TITLE
fix(Beatmap*): add missing enum values, add fallback to Beatmap's string getters

### DIFF
--- a/src/structures/osu/Beatmap.ts
+++ b/src/structures/osu/Beatmap.ts
@@ -190,7 +190,7 @@ export class Beatmap
 	 */
 	public get languageString(): string
 	{
-		return titleCase(BeatmapLanguage[this.language]);
+		return titleCase(BeatmapLanguage[this.language] ?? `Unknown Language: ${this.language}`);
 	}
 
 	/**
@@ -198,7 +198,7 @@ export class Beatmap
 	 */
 	public get genreString(): string
 	{
-		return titleCase(BeatmapGenre[this.genre]);
+		return titleCase(BeatmapGenre[this.genre] ?? `Unknown Genre: ${this.genre}`);
 	}
 
 	/**
@@ -206,7 +206,7 @@ export class Beatmap
 	 */
 	public get stateString(): string
 	{
-		return titleCase(BeatmapState[this.approved]);
+		return titleCase(BeatmapState[this.approved] ?? `Unknown State: ${this.approved}`);
 	}
 
 	/**

--- a/src/types/osu/BeatmapGenre.ts
+++ b/src/types/osu/BeatmapGenre.ts
@@ -10,4 +10,8 @@ export enum BeatmapGenre {
 	// No 8
 	HIP_HOP = 9,
 	ELECTRONIC,
+	METAL,
+	CLASSICAL,
+	FOLK,
+	JAZZ
 }

--- a/src/types/osu/BeatmapLanguage.ts
+++ b/src/types/osu/BeatmapLanguage.ts
@@ -1,6 +1,6 @@
 export enum BeatmapLanguage {
 	ANY,
-	OTHER,
+	UNSPECIFIED,
 	ENGLISH,
 	JAPANESE,
 	CHINESE,
@@ -11,4 +11,7 @@ export enum BeatmapLanguage {
 	SWEDISCH,
 	SPANISH,
 	ITALIAN,
+	RUSSIAN,
+	POLISH,
+	OTHER,
 }

--- a/src/types/osu/BeatmapMods.ts
+++ b/src/types/osu/BeatmapMods.ts
@@ -13,7 +13,7 @@ export enum BeatmapModsFlags {
 	FL = 1 << 10,
 	AP = 1 << 11,
 	SO = 1 << 12,
-	// Whatever Relax 2 is...
+	// RX2 = Autopilot
 	RX2 = 1 << 13,
 	PF = 1 << 14,
 	KEY4 = 1 << 15,


### PR DESCRIPTION
This PR adds the missing enum values for:
- Genres:  `METAL`, `CLASSICAL`, `FOLK`, and `JAZZ`
- Languages: `RUSSIAN`, `POLISH`, `UNSPECIFIED` (and fixes `OTHER`'s value)

This PR also adds a fallback to avoid throwing an error if an unknown (read: new) enum value is encountered.