### PR TITLE
fix(ImageCommand): properly credit weeb.sh in the embed footer

### DIFF
--- a/src/commands/interactive/image.ts
+++ b/src/commands/interactive/image.ts
@@ -89,6 +89,8 @@ class ImageCommand extends Command
 			embed.setImage(image.url);
 		}
 
+		embed.footer!.text += ' | Powered by weeb.sh';
+
 		return message.reply(embed);
 	}
 }


### PR DESCRIPTION
This PR adds the usual `powered by` into the footer of the response embed of the `ImageCommand` where it already is for other commands.

Credit where credit is due.
