### PR TITLE
release: v4.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 	</p>
 	<p align="center">
 		<a href="https://github.com/Hydractify/kanna_kobayashi/blob/stable/package.json#L3">
-			<img src="https://img.shields.io/badge/kanna_kobayashi-v4.7.0-fcbbd5.svg?style=flat-square" />
+			<img src="https://img.shields.io/badge/kanna_kobayashi-v4.7.1-fcbbd5.svg?style=flat-square" />
 		</a>
 		<a href="https://www.hydractify.org/discord">
 			<img src="https://img.shields.io/discord/298969150133370880.svg?style=flat-square&logo=discord">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kanna-kobayashi",
-	"version": "4.7.0",
+	"version": "4.7.1",
 	"private": true,
 	"description": "A community driven open-source application bot for Discord.",
 	"main": "bin/Shard.js",


### PR DESCRIPTION
#### Version bump v4.7.1 [#113]

# Patches
- [\~] Update `discord.js` to move to Discord's new domain [#112, db03fd909f058945da49d33511bd343cb3ffc0b3]
