### PR TITLE
feat: use the new timestamp markdown where possible

### DIFF
--- a/src/commands/info/emoji.ts
+++ b/src/commands/info/emoji.ts
@@ -1,5 +1,4 @@
 import { Emoji, Message } from 'discord.js';
-import * as moment from 'moment';
 
 import { Client } from '../../structures/Client';
 import { Command } from '../../structures/Command';
@@ -9,6 +8,7 @@ import { EmojiMatchType } from '../../types/EmojiMatchType';
 import { Emojis } from '../../types/Emojis';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
+import { TimestampFlag, timestampMarkdown } from '../../util/Util';
 
 class EmojiInfoCommand extends Command
 {
@@ -64,13 +64,10 @@ class EmojiInfoCommand extends Command
 		{ authorModel }: ICommandRunInfo,
 	): Promise<Message | Message[]>
 	{
-		const createdAtString: string = moment(emoji.createdTimestamp ?? 0).format('MM/DD/YYYY (HH:mm)');
-		const createdBeforeString: string = moment(emoji.createdTimestamp ?? 0).fromNow();
 		const embed: MessageEmbed = MessageEmbed.common(message, authorModel)
 			.addField('Name', emoji.name, true)
 			.addField('ID', emoji.id, true)
-			.addField('Created', createdAtString, true)
-			.addField('Relative', createdBeforeString, true)
+			.addField('Created', timestampMarkdown(emoji.createdTimestamp ?? 0, TimestampFlag.RelativeTime), true)
 			.addField('Link', `[Link](${emoji.url})`, true)
 			.setThumbnail(emoji.url);
 

--- a/src/commands/info/guild.ts
+++ b/src/commands/info/guild.ts
@@ -1,5 +1,4 @@
 import { User, Guild, Message, Role, Snowflake } from 'discord.js';
-import * as moment from 'moment';
 
 import { User as UserModel } from '../../models/User';
 import { Command } from '../../structures/Command';
@@ -7,7 +6,7 @@ import { CommandHandler } from '../../structures/CommandHandler';
 import { MessageEmbed } from '../../structures/MessageEmbed';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
-import { mapIterable, titleCase } from '../../util/Util';
+import { mapIterable, TimestampFlag, timestampMarkdown, titleCase } from '../../util/Util';
 
 class GuildInfoCommand extends Command
 {
@@ -79,7 +78,7 @@ class GuildInfoCommand extends Command
 
 			.addField(
 				'Guild creation',
-				moment(guild.createdTimestamp).format('MM/DD/YYYY [(]HH:mm[)]'),
+				timestampMarkdown(guild.createdTimestamp, TimestampFlag.RelativeTime),
 				true,
 			)
 			.addField('Owner', `Tag: ${ownerUser.tag}\nID: ${ownerUser.id}`, true)

--- a/src/commands/info/lookup.ts
+++ b/src/commands/info/lookup.ts
@@ -1,5 +1,4 @@
 import { Guild, Invite, Message } from 'discord.js';
-import * as moment from 'moment';
 
 import { User as UserModel } from '../../models/User';
 import { Command } from '../../structures/Command';
@@ -7,6 +6,7 @@ import { CommandHandler } from '../../structures/CommandHandler';
 import { MessageEmbed } from '../../structures/MessageEmbed';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
+import { TimestampFlag, timestampMarkdown } from '../../util/Util';
 import { Command as GuildInfoCommand } from './guild';
 
 class LookupCommand extends Command
@@ -70,8 +70,6 @@ class LookupCommand extends Command
 	{
 		const iconURL: string | null = guild!.iconURL();
 
-		const createdAt: moment.Moment = moment(guild!.createdAt);
-
 		return MessageEmbed.common(message, authorModel)
 			.setTitle(`Info about ${guild!.name}`)
 			.setThumbnail(iconURL)
@@ -83,7 +81,7 @@ class LookupCommand extends Command
 
 			.addField(
 				'Guild creation',
-				createdAt.utc().format('MM/DD/YYYY [(]HH:mm[)]'),
+				timestampMarkdown(guild!.createdTimestamp, TimestampFlag.RelativeTime),
 				true,
 			)
 

--- a/src/commands/info/osubeatmap.ts
+++ b/src/commands/info/osubeatmap.ts
@@ -9,7 +9,7 @@ import { Beatmap, Score } from '../../structures/osu';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
 import { OsuMode } from '../../types/osu/OsuMode';
-import { titleCase } from '../../util/Util';
+import { timestampMarkdown, titleCase } from '../../util/Util';
 
 class OsuBeatmapCommand extends Command
 {
@@ -149,8 +149,9 @@ class OsuBeatmapCommand extends Command
 			.addField(
 				'State',
 				[
+					`Submitted:\n  ${timestampMarkdown(beatmap.submitedAt)}\n`,
 					`${beatmap.stateString}`,
-					beatmap.approvedAt ? `, as of:\n${beatmap.approvedAt.format('DD/MM/YYYY (hh:mm)')}` : '',
+					beatmap.approvedAt ? `:\n  ${timestampMarkdown(beatmap.approvedAt)}` : '',
 				].join(''),
 				true)
 			.addField('ID | Set ID', `${beatmap.id} | ${beatmap.setId}`, true);
@@ -174,8 +175,9 @@ class OsuBeatmapCommand extends Command
 			.addField(
 				'State',
 				[
+					`Submitted:\n  ${timestampMarkdown(first.submitedAt)}\n`,
 					`${first.stateString}`,
-					first.approvedAt ? `, as of:\n${first.approvedAt.format('DD/MM/YYYY (hh:mm)')}` : '',
+					first.approvedAt ? `:\n  ${timestampMarkdown(first.approvedAt)}` : '',
 				].join(''),
 				true)
 			.addField('BPM', first.bpm, true)

--- a/src/commands/info/osuuser.ts
+++ b/src/commands/info/osuuser.ts
@@ -11,6 +11,7 @@ import { Emojis } from '../../types/Emojis';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
 import { OsuMode } from '../../types/osu/OsuMode';
+import { TimestampFlag, timestampMarkdown } from '../../util/Util';
 
 class OsuUserCommand extends Command
 {
@@ -112,7 +113,7 @@ class OsuUserCommand extends Command
 			const pp: string = score.pp ? ` -- **${score.pp.toFixed(2)}**` : '';
 			embed.addField(
 				`${beatmap.artist} - ${beatmap.title} [${beatmap.version}]${mods ? ` +${mods}` : ''}`,
-				`${score.rankEmoji} -- [URL](${beatmap.versionURL()}) -- ${score.date.fromNow() + pp}`,
+				`${score.rankEmoji} -- [URL](${beatmap.versionURL()}) -- ${timestampMarkdown(score.date, TimestampFlag.RelativeTime)}${pp}`,
 			);
 		}
 

--- a/src/commands/info/user.ts
+++ b/src/commands/info/user.ts
@@ -1,12 +1,11 @@
 import { Guild, GuildMember, Message, Role, Snowflake, User } from 'discord.js';
-import * as moment from 'moment';
 
 import { Command } from '../../structures/Command';
 import { CommandHandler } from '../../structures/CommandHandler';
 import { MessageEmbed } from '../../structures/MessageEmbed';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
-import { mapIterable } from '../../util/Util';
+import { mapIterable, TimestampFlag, timestampMarkdown } from '../../util/Util';
 
 class UserInfoCommand extends Command
 {
@@ -59,7 +58,7 @@ class UserInfoCommand extends Command
 				this.client.guilds.cache.filter((guild: Guild) => guild.members.cache.has(user.id)).size,
 				true,
 			)
-			.addField('Registered account', this._formatTimespan(user.createdTimestamp));
+			.addField('Registered account', timestampMarkdown(user.createdTimestamp, TimestampFlag.RelativeTime));
 
 		if (member)
 		{
@@ -68,7 +67,7 @@ class UserInfoCommand extends Command
 			const rolesString: string = mapIterable(roles.values());
 
 			embed
-				.addField('Joined this guild', this._formatTimespan(member.joinedTimestamp ?? 0), true)
+				.addField('Joined this guild', timestampMarkdown(member.joinedTimestamp ?? 0, TimestampFlag.RelativeTime), true)
 				.addField('Roles', rolesString || 'None');
 		}
 
@@ -76,11 +75,6 @@ class UserInfoCommand extends Command
 			.setImage(user.displayAvatarURL());
 
 		return message.channel.send(embed);
-	}
-
-	private _formatTimespan(from: number): string
-	{
-		return `${moment(from).format('MM/DD/YYYY (HH:mm)')} [${moment.duration(from - Date.now()).humanize()}]`;
 	}
 }
 

--- a/src/commands/user/profile.ts
+++ b/src/commands/user/profile.ts
@@ -9,7 +9,7 @@ import { CommandHandler } from '../../structures/CommandHandler';
 import { MessageEmbed } from '../../structures/MessageEmbed';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
-import { titleCase } from '../../util/Util';
+import { TimestampFlag, timestampMarkdown, titleCase } from '../../util/Util';
 
 class ProfileCommand extends Command
 {
@@ -109,19 +109,12 @@ class ProfileCommand extends Command
 			.addField('Level', `${userModel.level} (${(userModel.exp || 0).toLocaleString()} exp)`, true)
 			.addField('Reputation', (reputation || 0).toLocaleString(), true)
 			.addField('Badges', this.mapItems(userModel.badges), true)
-			.addField('Time', userTime, true)
+			.addField('Local Time', userTime, true)
 			.addField('Relationship', partnerString, true);
 
 		if (!userModel.partnerHidden && user === author && userModel.partnerId)
 		{
-			const offset: number = authorModel.timezone || 0;
-			const anniversary: string = moment(userModel.partnerSince ?? 0)
-				// .utc() because we .add() the utc offset to display the correct date
-				.utc()
-				.add(offset, 'hours')
-				.format('YYYY-MM-DD');
-
-			embed.addField('Relationship Anniversary', `${anniversary} (UTC ${offset >= 0 ? '+' : ''}${offset})`, true);
+			embed.addField('Relationship Anniversary', timestampMarkdown(userModel.partnerSince ?? 0, TimestampFlag.LongDate), true);
 		}
 
 		return embed;

--- a/src/commands/user/propose.ts
+++ b/src/commands/user/propose.ts
@@ -1,5 +1,4 @@
 import { Collection, CollectorFilter, GuildMember, Message, Snowflake, User } from 'discord.js';
-import * as moment from 'moment';
 import { Transaction } from 'sequelize';
 
 import { User as UserModel } from '../../models/User';
@@ -8,6 +7,7 @@ import { CommandHandler } from '../../structures/CommandHandler';
 import { Emojis } from '../../types/Emojis';
 import { GuildMessage } from '../../types/GuildMessage';
 import { ICommandRunInfo } from '../../types/ICommandRunInfo';
+import { TimestampFlag, timestampMarkdown } from '../../util/Util';
 
 class ProposeCommand extends Command
 {
@@ -81,7 +81,7 @@ class ProposeCommand extends Command
 		{
 			await message.reply([
 				`sorry but not enough time has passed since you two got together! ${Emojis.KannaShy}`,
-				`Try again ${moment(until).fromNow()}.`,
+				`Try again ${timestampMarkdown(until, TimestampFlag.RelativeTime)}.`,
 			].join('\n'));
 
 			return false;

--- a/src/structures/osu/Beatmap.ts
+++ b/src/structures/osu/Beatmap.ts
@@ -1,5 +1,3 @@
-import { Moment, utc } from 'moment';
-
 import { BeatmapGenre } from '../../types/osu/BeatmapGenre';
 import { BeatmapLanguage } from '../../types/osu/BeatmapLanguage';
 import { BeatmapState } from '../../types/osu/BeatmapState';
@@ -57,7 +55,7 @@ export class Beatmap
 	/**
 	 * When the map was approved
 	 */
-	public readonly approvedAt: Moment | undefined;
+	public readonly approvedAt: Date | null;
 	/**
 	 * Artist of the song used in the beatmap
 	 */
@@ -131,6 +129,10 @@ export class Beatmap
 	 */
 	public readonly setId: string;
 	/**
+	 * When this beatmap was submitted.
+	 */
+	public readonly submitedAt: Date;
+	/**
 	 * Tags of the beatmap
 	 */
 	public readonly tags: string;
@@ -141,7 +143,7 @@ export class Beatmap
 	/**
 	 * Whenever this beatmap was updated last
 	 */
-	public readonly updatedAt: Moment;
+	public readonly updatedAt: Date;
 	/**
 	 * Name of the `difficulty`
 	 */
@@ -153,8 +155,9 @@ export class Beatmap
 	public constructor(data: { [key: string]: string })
 	{
 		this.approved = Number(data.approved);
-		this.approvedAt = data.approved_date ? utc(`${data.approved_date}+08:00`) : undefined;
-		this.updatedAt = utc(`${data.last_update}+80:00`);
+		this.approvedAt = data.approved_date ? new Date(`${data.approved_date}Z`) : null;
+		this.updatedAt = new Date(`${data.last_update}Z`);
+		this.submitedAt = new Date(`${data.submit_date}Z`);
 		this.artist = data.artist;
 		this.id = data.beatmap_id;
 		this.setId = data.beatmapset_id;

--- a/src/structures/osu/Score.ts
+++ b/src/structures/osu/Score.ts
@@ -1,5 +1,3 @@
-import { Moment, utc } from 'moment';
-
 import { Emojis } from '../../types/Emojis';
 import { BeatmapMods } from '../../types/osu/BeatmapMods';
 import { OsuMode } from '../../types/osu/OsuMode';
@@ -46,7 +44,7 @@ export class Score
 	/**
 	 * Date the score was achieved
 	 */
-	public readonly date: Moment;
+	public readonly date: Date;
 	/**
 	 * Highest combo reached in the score
 	 */
@@ -118,7 +116,7 @@ export class Score
 		this.perfect = data.perfect === '1';
 		this._enabledMods = Number(data.enabled_mods);
 		this.userId = data.user_id;
-		this.date = utc(`${data.date}+08:00`);
+		this.date = new Date(`${data.date}Z`);
 		this.rank = data.rank;
 		this.pp = data.pp ? Number(data.pp) : undefined;
 

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -239,3 +239,50 @@ export function catchErrors(...errors: ObjectValueType<typeof Constants['APIErro
 		throw reason;
 	};
 }
+
+/**
+ * How the timestamp should be formatted.
+ * Note that the locale of the Discord client of the viewing user will be used.
+ * The examples use `en_US`, the actual values will differ for other locales.
+ */
+export enum TimestampFlag {
+	/**
+	 * Example: `16:20`
+	 */
+	ShortTime = 't',
+	/**
+	 * Example: `16:20:30`
+	 */
+	LongTime = 'T',
+	/**
+	 * Example: `20/04/2021`
+	 */
+	ShortDate = 'd',
+	/**
+	 * Example: `20 April 2021`
+	 */
+	LongDate = 'D',
+	/**
+	 * Example: `20 April 2021 16:20`
+	 */
+	ShortDateTime = 'f',
+	/**
+	 * Example: `Tuesday, 20 April 2021 16:20`
+	 */
+	LongDateTime = 'F',
+	/**
+	 * Example: `2 months ago`
+	 */
+	RelativeTime = 'R',
+}
+
+/**
+ * Converts the given timestamp to Discord markdown for a timestamp.
+ * @param ts The timestamp to format
+ * @param flag How to format the timestamp
+ * @returns The resulting markdown
+ */
+export function timestampMarkdown(ts: Date | number, flag?: TimestampFlag): string
+{
+	return `<t:${Math.trunc((+ts) / 1000)}${flag ? `:${flag}` : ''}>`;
+}


### PR DESCRIPTION
This PR makes use of the new timestamp markdown has added where it is of use.

This markdown is not yet available on all clients (looking at you, mobile clients), so this PR has to sit here a for a bit.