### PR TITLE
fix(Client): ensure that a guild is available in guildDelete/Create handler

### DIFF
--- a/src/structures/Client.ts
+++ b/src/structures/Client.ts
@@ -170,6 +170,8 @@ export class Client extends DJSClient
 	@RavenContext
 	protected async _onGuild(guild: Guild, left: boolean): Promise<void>
 	{
+		if (!guild.available) return;
+
 		this._guildCount.set(this.guilds.cache.size);
 		captureBreadcrumb({ category: left ? 'guildDelete' : 'guildCreate', level: 'debug' });
 


### PR DESCRIPTION
Discord may sent guild delete packets for unavailable guilds before ready when a guild is "soft deleted".
We are not handling these (and the documentation states to do so anyway), so here we go.
(We only have the id of unavailable guilds, we couldn't do much with that anyway.)