### PR TITLE
fix(SetGameCommand): do not assume that the client is ready/logged in

### DIFF
--- a/src/commands/unique/setgame.ts
+++ b/src/commands/unique/setgame.ts
@@ -99,11 +99,11 @@ class SetGameCommand extends Command
 		return { type: 'PLAYING', name: `k!help | on ${totalGuilds} guilds` };
 	}
 
-	private setActivity(client: Client, [activity]: ActivityOptions[]): Promise<Presence[]>
+	private setActivity(client: Client, [activity]: ActivityOptions[]): Promise<(undefined | Presence)[]>
 	{
 		return Promise.all(
 			client.ws.shards.map((shard: WebSocketShard, shardId: number) =>
-				client.user!.setActivity({
+				client.user?.setActivity({
 					...activity,
 					name: `${activity.name} [${shardId}]`,
 					shardID: shardId,


### PR DESCRIPTION
Shard 0 will start regularly refreshing the presence (since Discord may lose those on session transfers) after all shards are ready.
When a shard restarts for whatever reason, that timer will keep running and may elapse before said shard is ready and cause it to crash since I forgot to account for restarting shards.

This will take care of that.